### PR TITLE
Add generic type for the Enqueue and ContinueWithJob meth…

### DIFF
--- a/src/Hangfire.Atoms/Builder/AtomBuilder.cs
+++ b/src/Hangfire.Atoms/Builder/AtomBuilder.cs
@@ -148,6 +148,26 @@ namespace Hangfire.Atoms.Builder
             return CreateSubatomInternal(action, state, atomProgress);
         }
 
+        public string Enqueue<T>(
+            [InstantHandle] Expression<Func<T, Task>> action, 
+            JobContinuationOptions atomProgress)
+        {
+            var job = Job.FromExpression(action);
+            var nextState = new EnqueuedState();
+            return CreateSubatomInternal(job, nextState, atomProgress);
+        }
+
+        public string ContinueJobWith<T>(
+            string parentId, 
+            [InstantHandle] Expression<Func<T, Task>> action, 
+            JobContinuationOptions jobContinuationOptions = JobContinuationOptions.OnlyOnSucceededState,
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState)
+        {
+            var job = Job.FromExpression(action);
+            var nextState = new AwaitingState(parentId, new EnqueuedState(), jobContinuationOptions);
+            return CreateSubatomInternal(job, nextState, atomProgress);
+        }
+
         public string Build()
         {
             try

--- a/src/Hangfire.Atoms/Builder/AtomBuilder.cs
+++ b/src/Hangfire.Atoms/Builder/AtomBuilder.cs
@@ -150,7 +150,16 @@ namespace Hangfire.Atoms.Builder
 
         public string Enqueue<T>(
             [InstantHandle] Expression<Func<T, Task>> action, 
-            JobContinuationOptions atomProgress)
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState)
+        {
+            var job = Job.FromExpression(action);
+            var nextState = new EnqueuedState();
+            return CreateSubatomInternal(job, nextState, atomProgress);
+        }
+        
+        public string Enqueue<T>(
+            [InstantHandle] Expression<Action<T>> action, 
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState)
         {
             var job = Job.FromExpression(action);
             var nextState = new EnqueuedState();
@@ -160,6 +169,17 @@ namespace Hangfire.Atoms.Builder
         public string ContinueJobWith<T>(
             string parentId, 
             [InstantHandle] Expression<Func<T, Task>> action, 
+            JobContinuationOptions jobContinuationOptions = JobContinuationOptions.OnlyOnSucceededState,
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState)
+        {
+            var job = Job.FromExpression(action);
+            var nextState = new AwaitingState(parentId, new EnqueuedState(), jobContinuationOptions);
+            return CreateSubatomInternal(job, nextState, atomProgress);
+        }
+        
+        public string ContinueJobWith<T>(
+            string parentId, 
+            [InstantHandle] Expression<Action<T>> action, 
             JobContinuationOptions jobContinuationOptions = JobContinuationOptions.OnlyOnSucceededState,
             JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState)
         {

--- a/src/Hangfire.Atoms/Builder/IAtomBuilder.cs
+++ b/src/Hangfire.Atoms/Builder/IAtomBuilder.cs
@@ -59,5 +59,12 @@ namespace Hangfire.Atoms.Builder
             [InstantHandle] Expression<Func<Task>> action,
             JobContinuationOptions jobContinuationOptions = JobContinuationOptions.OnlyOnSucceededState,
             JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState);
+
+        string ContinueJobWith<T>(
+            string parentId, 
+            [InstantHandle] Expression<Func<T, Task>> action, 
+            JobContinuationOptions jobContinuationOptions = JobContinuationOptions.OnlyOnSucceededState,
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState);
+        );
     }
 }

--- a/src/Hangfire.Atoms/Builder/IAtomBuilder.cs
+++ b/src/Hangfire.Atoms/Builder/IAtomBuilder.cs
@@ -18,7 +18,11 @@ namespace Hangfire.Atoms.Builder
 
         string Enqueue<T>(
             [InstantHandle] Expression<Func<T, Task>> action, 
-            JobContinuationOptions atomProgress);
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState);
+
+        string Enqueue<T>(
+            [InstantHandle] Expression<Action<T>> action, 
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState);
 
         string Schedule(
             [InstantHandle] Expression<Action> action,
@@ -69,6 +73,11 @@ namespace Hangfire.Atoms.Builder
             [InstantHandle] Expression<Func<T, Task>> action, 
             JobContinuationOptions jobContinuationOptions = JobContinuationOptions.OnlyOnSucceededState,
             JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState);
-        );
+
+        string ContinueJobWith<T>(
+            string parentId,
+            [InstantHandle] Expression<Action<T>> action,
+            JobContinuationOptions jobContinuationOptions = JobContinuationOptions.OnlyOnSucceededState,
+            JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState);
     }
 }

--- a/src/Hangfire.Atoms/Builder/IAtomBuilder.cs
+++ b/src/Hangfire.Atoms/Builder/IAtomBuilder.cs
@@ -16,6 +16,10 @@ namespace Hangfire.Atoms.Builder
             [InstantHandle] Expression<Func<Task>> action,
             JobContinuationOptions atomProgress = JobContinuationOptions.OnlyOnSucceededState);
 
+        string Enqueue<T>(
+            [InstantHandle] Expression<Func<T, Task>> action, 
+            JobContinuationOptions atomProgress);
+
         string Schedule(
             [InstantHandle] Expression<Action> action,
             DateTime enqueueAt,

--- a/tests/Hangfire.Atoms.Tests.Web/Startup.cs
+++ b/tests/Hangfire.Atoms.Tests.Web/Startup.cs
@@ -22,7 +22,7 @@ namespace Hangfire.Atoms.Tests.Web
             services.AddMvc();
             services.AddHangfire(configuration =>
             {
-                configuration.UseRedisStorage("192.168.5.32");
+                configuration.UseRedisStorage("127.0.0.1");
                 configuration.UseAtoms();
             });
         }
@@ -48,6 +48,7 @@ namespace Hangfire.Atoms.Tests.Web
             RecurringJob.AddOrUpdate("test-5", () => TestSuite.AtomTest5(), Cron.Yearly, TimeZoneInfo.Utc);
             RecurringJob.AddOrUpdate("test-6", () => TestSuite.AtomTest6(), Cron.Yearly, TimeZoneInfo.Utc);
             RecurringJob.AddOrUpdate("test-7", () => TestSuite.AtomTest7(), Cron.Yearly, TimeZoneInfo.Utc);
+            RecurringJob.AddOrUpdate("test-8", () => TestSuite.AtomTest8(), Cron.Yearly, TimeZoneInfo.Utc);
 
             var asyncTestSuite = new AsyncTestSuite();
             RecurringJob.AddOrUpdate("test-async", () => asyncTestSuite.AsyncAtomTest(), Cron.Yearly, TimeZoneInfo.Utc);


### PR DESCRIPTION
This pull request adds the ability to use `Enqueue<T>` and `ContineuWithJob<T>` as seen in `Hangfire`. Originally I wanted to use a Extension to add these methods to `AtomBuilder`-class but there is no method which accepts a `Job` instead of `Express` action so that wasn't possible so I solved the problem this. 

Fixes issue #4 