### PR TITLE
Remove usage of JobStorage.Current

### DIFF
--- a/src/Hangfire.Atoms/Atom.cs
+++ b/src/Hangfire.Atoms/Atom.cs
@@ -7,34 +7,34 @@ namespace Hangfire.Atoms
 {
     public static partial class Atom
     {
-        public static string Enqueue(this IBackgroundJobClient client, string name, Action<IAtomBuilder> buildAtom)
+        public static string Enqueue(this IBackgroundJobClientV2 client, string name, Action<IAtomBuilder> buildAtom)
         {
-            var builder = new AtomBuilder(name, JobStorage.Current, client, buildAtom);
+            var builder = new AtomBuilder(name, client.Storage, client, buildAtom);
             return builder.Build();
         }
 
-        public static string Schedule(this IBackgroundJobClient client, string name, TimeSpan enqueueIn, Action<IAtomBuilder> buildAtom)
+        public static string Schedule(this IBackgroundJobClientV2 client, string name, TimeSpan enqueueIn, Action<IAtomBuilder> buildAtom)
         {
-            var builder = new AtomBuilder(name, JobStorage.Current, client, buildAtom, new ScheduledState(enqueueIn));
+            var builder = new AtomBuilder(name, client.Storage, client, buildAtom, new ScheduledState(enqueueIn));
             return builder.Build();
         }
 
-        public static string Schedule(this IBackgroundJobClient client, string name, DateTime enqueueAt, Action<IAtomBuilder> buildAtom)
+        public static string Schedule(this IBackgroundJobClientV2 client, string name, DateTime enqueueAt, Action<IAtomBuilder> buildAtom)
         {
-            var builder = new AtomBuilder(name, JobStorage.Current, client, buildAtom, new ScheduledState(enqueueAt));
+            var builder = new AtomBuilder(name, client.Storage, client, buildAtom, new ScheduledState(enqueueAt));
             return builder.Build();
         }
 
-        public static string ContinueJobWith(this IBackgroundJobClient client, string parentId, string name, Action<IAtomBuilder> buildAtom)
+        public static string ContinueJobWith(this IBackgroundJobClientV2 client, string parentId, string name, Action<IAtomBuilder> buildAtom)
         {
-            var builder = new AtomBuilder(name, JobStorage.Current, client, buildAtom, new AwaitingState(parentId));
+            var builder = new AtomBuilder(name, client.Storage, client, buildAtom, new AwaitingState(parentId));
             return builder.Build();
         }
 
-        public static string OnTriggerSet(this IBackgroundJobClient client, string triggerName, string name, Action<IAtomBuilder> buildAtom)
+        public static string OnTriggerSet(this IBackgroundJobClientV2 client, string triggerName, string name, Action<IAtomBuilder> buildAtom)
         {
             var triggerId = client.OnTriggerSet(triggerName);
-            var builder = new AtomBuilder(name, JobStorage.Current, client, buildAtom, new AwaitingState(triggerId));
+            var builder = new AtomBuilder(name, client.Storage, client, buildAtom, new AwaitingState(triggerId));
             return builder.Build();
         }
 

--- a/src/Hangfire.Atoms/ConfigurationBootstrapperExtensions.cs
+++ b/src/Hangfire.Atoms/ConfigurationBootstrapperExtensions.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using Hangfire.Annotations;
+﻿using Hangfire.Annotations;
 using Hangfire.Atoms.Dashboard;
 using Hangfire.Atoms.Dashboard.Pages;
 using Hangfire.Atoms.States;
 using Hangfire.Dashboard;
-using Hangfire.Storage;
 
 namespace Hangfire.Atoms
 {
@@ -13,8 +11,6 @@ namespace Hangfire.Atoms
         [PublicAPI]
         public static IGlobalConfiguration UseAtoms(this IGlobalConfiguration configuration)
         {
-            ThrowIfStorageIsNotSupported();
-
             SetupAtomMachinery();
             SetupDashboard();
 
@@ -67,23 +63,6 @@ namespace Hangfire.Atoms
 
             DashboardRoutes.Routes.AddRazorPage("/jobs/triggers", x => new TriggersPage());
             JobsSidebarMenu.Items.Add(TriggerJobSidebar.RenderMenu);
-        }
-
-        private static void ThrowIfStorageIsNotSupported()
-        {
-            if (JobStorage.Current == null) throw new InvalidOperationException("JobStorage.Current == null");
-
-            using var connection = JobStorage.Current.GetConnection();
-            var jsc = connection as JobStorageConnection;
-            if (jsc == null)
-                throw new InvalidOperationException(
-                    "JobStorage.Current.GetConnection() doesn't implement JobStorageConnection");
-
-            using var tr = connection.CreateWriteTransaction();
-            var jst = tr as JobStorageTransaction;
-            if (jst == null)
-                throw new InvalidOperationException(
-                    "JobStorage.Current.GetConnection().CreateWriteTransaction() doesn't implement JobStorageTransaction");
         }
     }
 }

--- a/src/Hangfire.Atoms/Dashboard/HtmlUtils.cs
+++ b/src/Hangfire.Atoms/Dashboard/HtmlUtils.cs
@@ -9,23 +9,8 @@ namespace Hangfire.Atoms.Dashboard
 
         public static NonEscapedString AtomLink(this HtmlHelper helper, string jobAtomId)
         {
-            var url = GetUrlHelper(helper);
-            var href = url.To($"/jobs/atoms/{jobAtomId}");
+            var href = helper.Page.Url.To($"/jobs/atoms/{jobAtomId}");
             return new NonEscapedString($"<a href=\"{href}\">{jobAtomId}</a>");
-        }
-
-        private static UrlHelper GetUrlHelper(this HtmlHelper htmlHelper)
-        {
-            var page = new EmptyPage();
-            _ = htmlHelper.RenderPartial(page);
-            return page.Url;
-        }
-
-        private class EmptyPage : RazorPage
-        {
-            public override void Execute()
-            {
-            }
         }
     }
 }

--- a/src/Hangfire.Atoms/Hangfire.Atoms.csproj
+++ b/src/Hangfire.Atoms/Hangfire.Atoms.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hangfire.Core" Version="[1.7.19,1.8)" />
+        <PackageReference Include="Hangfire.Core" Version="1.8.1" />
         <PackageReference Include="RazorGenerator.MsBuild" Version="2.5.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/Hangfire.Atoms/States/AtomDeletedStateElectionFilter.cs
+++ b/src/Hangfire.Atoms/States/AtomDeletedStateElectionFilter.cs
@@ -33,7 +33,7 @@ namespace Hangfire.Atoms.States
                 if (isAtom) // we deal with atom itself
                 {
                     var atomId = context.BackgroundJob.Id;
-                    DeleteAsAtom(jsc, atomId);
+                    DeleteAsAtom(jsc, context.Storage, atomId);
                 }
                 else // it's just subatom
                 {
@@ -48,13 +48,13 @@ namespace Hangfire.Atoms.States
             }
         }
 
-        private void DeleteAsAtom(JobStorageConnection jsc, string atomId)
+        private void DeleteAsAtom(JobStorageConnection jsc, JobStorage storage, string atomId)
         {
             var subatomIds = jsc.GetAllItemsFromSet(Atom.GenerateSubAtomKeys(atomId));
 
             foreach (var subatomId in subatomIds)
             {
-                var context = new StateChangeContext(JobStorage.Current, jsc, subatomId, new DeletedState());
+                var context = new StateChangeContext(storage, jsc, subatomId, new DeletedState());
                 _stateChanger.ChangeState(context);
             }
         }

--- a/src/Hangfire.Atoms/Trigger.cs
+++ b/src/Hangfire.Atoms/Trigger.cs
@@ -26,10 +26,9 @@ namespace Hangfire.Atoms
         }
 
         [PublicAPI]
-        public static void SetTrigger(this IBackgroundJobClient client, string triggerName)
+        public static void SetTrigger(this IBackgroundJobClientV2 client, string triggerName)
         {
-            var storage = JobStorage.Current;
-            using var connection = storage.GetJobStorageConnection();
+            using var connection = client.Storage.GetJobStorageConnection();
 
             SetTriggerInternal(client, connection, triggerName);
         }

--- a/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
+++ b/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HangFire" Version="1.7.32" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.32" />
+    <PackageReference Include="HangFire" Version="1.8.1" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.1" />
     <PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.5" />
-    <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.6" />
+    <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Hangfire.Atoms.Tests.Web/Program.cs
+++ b/tests/Hangfire.Atoms.Tests.Web/Program.cs
@@ -31,17 +31,17 @@ app.MapGet("/", context =>
 app.UseDeveloperExceptionPage();
 
 app.UseHangfireDashboard(dashboardLocation, new DashboardOptions { StatsPollingInterval = 1000 });
-RecurringJob.AddOrUpdate("test-1", () => TestSuite.AtomTest(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-2", () => TestSuite.AtomTest2(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-3", () => TestSuite.AtomTest3(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-4", () => TestSuite.AtomTest4(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-5", () => TestSuite.AtomTest5(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-6", () => TestSuite.AtomTest6(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-7", () => TestSuite.AtomTest7(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-8", () => TestSuite.AtomTest8(), Cron.Yearly, TimeZoneInfo.Utc);
+RecurringJob.AddOrUpdate("test-1", () => TestSuite.AtomTest(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-2", () => TestSuite.AtomTest2(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-3", () => TestSuite.AtomTest3(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-4", () => TestSuite.AtomTest4(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-5", () => TestSuite.AtomTest5(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-6", () => TestSuite.AtomTest6(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-7", () => TestSuite.AtomTest7(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-8", () => TestSuite.AtomTest8(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
 
 var asyncTestSuite = new AsyncTestSuite();
-RecurringJob.AddOrUpdate("test-async", () => asyncTestSuite.AsyncAtomTest(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-async-2", () => asyncTestSuite.AsyncAtomTest2(), Cron.Yearly, TimeZoneInfo.Utc);
+RecurringJob.AddOrUpdate("test-async", () => asyncTestSuite.AsyncAtomTest(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-async-2", () => asyncTestSuite.AsyncAtomTest2(), Cron.Yearly, new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
 
 app.Run();


### PR DESCRIPTION
When using the ASP.NET Core Hangfire integration, i.e. `services.AddHangfire(...)` the `JobStorage.Current` static property may never be assigned through the application lifetime as it's injected.

We can get rid of `JobStorage.Current` and access the storage from either the new `IBackgroundJobClientV2` interface introduced in Hangfire 1.8 (Atom + Trigger classes) or through the `ApplyStateContext` (AtomDeletedStateElectionFilter class).

Note that I have opened this pull request as a _draft_ since it depends on Hangfire 1.8.0-rc2 which is not yet the final 1.8 version.