### PR TITLE
Bump to hangfire 1.8

### DIFF
--- a/src/Hangfire.Atoms/Hangfire.Atoms.csproj
+++ b/src/Hangfire.Atoms/Hangfire.Atoms.csproj
@@ -22,6 +22,7 @@
 
     <!-- Full MSBuild is required to generate Razor classes -->
     <PropertyGroup>
+		<RazorViewsCodeGenDirectory>$(MSBuildProjectDirectory)\</RazorViewsCodeGenDirectory>
         <MSBuild14FullPath>$(MSBuildProgramFiles32)\MSBuild\14.0\bin\MSBuild.exe</MSBuild14FullPath>
         <MSBuildCurrentFullPath>$(MSBuildBinPath)\MSBuild.exe</MSBuildCurrentFullPath>
         <RazorProjectFile>Razor.build</RazorProjectFile>

--- a/src/Hangfire.Atoms/Hangfire.Atoms.csproj
+++ b/src/Hangfire.Atoms/Hangfire.Atoms.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hangfire.Core" Version="[1.7.19,1.8.18]" />
+        <PackageReference Include="Hangfire.Core" Version="[1.7.19,1.9]" />
         <PackageReference Include="RazorGenerator.MsBuild" Version="2.5.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/Hangfire.Atoms/Hangfire.Atoms.csproj
+++ b/src/Hangfire.Atoms/Hangfire.Atoms.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hangfire.Core" Version="[1.7.19,1.8)" />
+        <PackageReference Include="Hangfire.Core" Version="[1.7.19,1.8.18]" />
         <PackageReference Include="RazorGenerator.MsBuild" Version="2.5.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
+++ b/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
@@ -8,8 +8,7 @@
   <ItemGroup>
     <PackageReference Include="HangFire" Version="1.7.32" />
     <PackageReference Include="Hangfire.Core" Version="1.7.32" />
-    <PackageReference Include="Hangfire.PostgreSql.ahydrax" Version="1.7.5" />
-    <PackageReference Include="Hangfire.Redis.StackExchange" Version="1.8.6" />
+    <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
+++ b/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <LangVersion>11</LangVersion>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
+++ b/tests/Hangfire.Atoms.Tests.Web/Hangfire.Atoms.Tests.Web.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HangFire" Version="1.7.32" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.32" />
+    <PackageReference Include="HangFire" Version="1.8.18" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.18" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
   </ItemGroup>
 

--- a/tests/Hangfire.Atoms.Tests.Web/Program.cs
+++ b/tests/Hangfire.Atoms.Tests.Web/Program.cs
@@ -29,17 +29,17 @@ app.MapGet("/", context =>
 app.UseDeveloperExceptionPage();
 
 app.UseHangfireDashboard(dashboardLocation, new DashboardOptions { StatsPollingInterval = 1000 });
-RecurringJob.AddOrUpdate("test-1", () => TestSuite.AtomTest(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-2", () => TestSuite.AtomTest2(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-3", () => TestSuite.AtomTest3(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-4", () => TestSuite.AtomTest4(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-5", () => TestSuite.AtomTest5(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-6", () => TestSuite.AtomTest6(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-7", () => TestSuite.AtomTest7(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-8", () => TestSuite.AtomTest8(), Cron.Yearly, TimeZoneInfo.Utc);
+RecurringJob.AddOrUpdate("test-1", () => TestSuite.AtomTest(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-2", () => TestSuite.AtomTest2(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-3", () => TestSuite.AtomTest3(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-4", () => TestSuite.AtomTest4(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-5", () => TestSuite.AtomTest5(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-6", () => TestSuite.AtomTest6(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-7", () => TestSuite.AtomTest7(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-8", () => TestSuite.AtomTest8(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
 
 var asyncTestSuite = new AsyncTestSuite();
-RecurringJob.AddOrUpdate("test-async", () => asyncTestSuite.AsyncAtomTest(), Cron.Yearly, TimeZoneInfo.Utc);
-RecurringJob.AddOrUpdate("test-async-2", () => asyncTestSuite.AsyncAtomTest2(), Cron.Yearly, TimeZoneInfo.Utc);
+RecurringJob.AddOrUpdate("test-async", () => asyncTestSuite.AsyncAtomTest(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
+RecurringJob.AddOrUpdate("test-async-2", () => asyncTestSuite.AsyncAtomTest2(), Cron.Yearly, new RecurringJobOptions() { TimeZone = TimeZoneInfo.Utc });
 
 app.Run();

--- a/tests/Hangfire.Atoms.Tests.Web/Program.cs
+++ b/tests/Hangfire.Atoms.Tests.Web/Program.cs
@@ -6,12 +6,10 @@ using Hangfire.Atoms.Tests.Web;
 using Microsoft.AspNetCore.Builder;
 
 var builder = WebApplication.CreateBuilder(args);
-var connectionString = Environment.GetEnvironmentVariable("Hangfire_PostgreSql_ConnectionString");
 
 builder.Services.AddHangfire(configuration =>
 {
     configuration.UseInMemoryStorage();
-    //configuration.UseRedisStorage("192.168.5.32");
     configuration.UseAtoms();
 });
 

--- a/tests/Hangfire.Atoms.Tests.Web/Program.cs
+++ b/tests/Hangfire.Atoms.Tests.Web/Program.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Hangfire;
 using Hangfire.Atoms;
 using Hangfire.Atoms.Tests.Web;
-using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Builder;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,8 +10,7 @@ var connectionString = Environment.GetEnvironmentVariable("Hangfire_PostgreSql_C
 
 builder.Services.AddHangfire(configuration =>
 {
-    configuration.UsePostgreSqlStorage(connectionString);
-    configuration.UsePostgreSqlMetrics();
+    configuration.UseInMemoryStorage();
     //configuration.UseRedisStorage("192.168.5.32");
     configuration.UseAtoms();
 });


### PR DESCRIPTION
I have made changes to allow use Hangfire 1.8.18.

In example app I changed storage provider to InMemory to be easily used for everyone without having real DB and updated usage of AddOrUpdate, to new version (AddOrUpdate with TimeZone is deprecated).
